### PR TITLE
给stylesheet文件添加id属性

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html lang="{{ language }}" class="{{ default_theme }}" dir="{{ text_direction }}">
+<html lang="{{ language }}" class="{{ default_theme }}" sidebar-visible dir="{{ text_direction }}">
     <head>
         <!-- Book generated using mdBook -->
         <meta charset="UTF-8">
@@ -53,7 +53,7 @@
         <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         {{/if}}
     </head>
-    <body class="sidebar-visible no-js">
+    <body class="no-js">
     <div id="body-container">
         <!-- Provide site root to javascript -->
         <script>
@@ -104,8 +104,8 @@
                 sidebar = 'hidden';
             }
             sidebar_toggle.checked = sidebar === 'visible';
-            body.classList.remove('sidebar-visible');
-            body.classList.add("sidebar-" + sidebar);
+            html.classList.remove('sidebar-visible');
+            html.classList.add("sidebar-" + sidebar);
         </script>
 
         <nav id="sidebar" class="sidebar" aria-label="Table of contents">

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -39,9 +39,9 @@
         {{/if}}
 
         <!-- Highlight.js Stylesheets -->
-        <link rel="stylesheet" href="{{ path_to_root }}highlight.css">
-        <link rel="stylesheet" href="{{ path_to_root }}tomorrow-night.css">
-        <link rel="stylesheet" href="{{ path_to_root }}ayu-highlight.css">
+        <link rel="stylesheet" id="highlight-css" href="{{ path_to_root }}highlight.css">
+        <link rel="stylesheet" id="tomorrow-night-css" href="{{ path_to_root }}tomorrow-night.css">
+        <link rel="stylesheet" id="ayu-highlight-css" href="{{ path_to_root }}ayu-highlight.css">
 
         <!-- Custom theme stylesheets -->
         {{#each additional_css}}

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html lang="{{ language }}" class="{{ default_theme }}" sidebar-visible dir="{{ text_direction }}">
+<html lang="{{ language }}" class="{{ default_theme }} sidebar-visible" dir="{{ text_direction }}">
     <head>
         <!-- Book generated using mdBook -->
         <meta charset="UTF-8">


### PR DESCRIPTION
Fix #49 

mdBook从 rust-lang/mdBook@879449447f9b69987b33308cc1fbf6d579d1686c 开始使用id选择css文件的标签。

由于仓库维护了自己的`index.hbs`。因而在初始化样式时，`stylesheets`里面的成员都为`null`，导致后续设置禁用样式的时候发生失败，进而导致不同的css规则互相干扰而出现颜色错位。

通过指定`id`以解决此问题。

---

> [!CAUTION]
> `mdBook` 上游已进一步将ID指定为 `mdbook-xxx-css` rust-lang/mdBook#2808，但是mdBook v0.5还处于alpha阶段，等上游更新后还需要重新修改为对应的id
